### PR TITLE
Vanilla attention

### DIFF
--- a/fb_sweep/README.md
+++ b/fb_sweep/README.md
@@ -1,0 +1,167 @@
+## Getting started
+
+To train a big Transformer model on WMT'16 En-De:
+
+```shell script
+# assuming fairseq is checked out into ~/src/fairseq-py:
+
+$ cd ~/src/fairseq-py
+$ python ./fb_sweep/sweep_wmt_en2de_transformer_big.py \
+  --data ~myleott/data/data-bin/wmt16_en_de_bpe32k/ \
+  --prefix test_experiment_1234 \
+  --num-trials -1 \
+  --num-gpus 8 \
+  --partition learnfair \
+  --dry-run
+```
+
+Remove the `--dry-run` option to actually launch a job on the cluster.
+
+## Configuring the sweep
+
+Hyperparameter options can be configured in each sweep script.
+For example, in `sweep_wmt_en2de_transformer_big.py` we might have:
+
+```python
+def get_grid(args):
+    return [
+        hyperparam("--fp16", save_dir_key=lambda val: "fp16"),
+        hyperparam("--max-update", 300000, save_dir_key=lambda val: f"maxupd{val}"),
+        # hyperparam("--save-interval", 600, save_dir_key=lambda val: f"save_interval{val}"),
+
+        hyperparam("--arch", "transformer_vaswani_wmt_en_de_big", save_dir_key=lambda val: val),
+        hyperparam("--share-all-embeddings", save_dir_key=lambda val: "shareemb"),
+
+        hyperparam("--optimizer", "adam", save_dir_key=lambda val: val),
+        hyperparam("--adam-betas", "(0.9, 0.98)", save_dir_key=lambda val: "beta0.9,0.98"),
+        hyperparam("--lr-scheduler", "inverse_sqrt"),
+        hyperparam("--warmup-init-lr", 1e-7),
+        hyperparam("--warmup-updates", 4000, save_dir_key=lambda val: f"warmup{val}"),
+        hyperparam("--lr", [1e-4, 5e-4], save_dir_key=lambda val: f"lr{val}"),
+        hyperparam("--clip-norm", 0.0, save_dir_key=lambda val: f"clip{val}"),
+
+        hyperparam("--dropout", 0.3, save_dir_key=lambda val: f"drop{val}"),
+        hyperparam("--weight-decay", 0.0, save_dir_key=lambda val: f"wd{val}"),
+        hyperparam("--criterion", "label_smoothed_cross_entropy"),
+        hyperparam("--label-smoothing", 0.1, save_dir_key=lambda val: f"ls{val}"),
+
+        hyperparam("--max-tokens", 3584, save_dir_key=lambda val: f"maxtok{val}"),
+        hyperparam("--seed", 2, save_dir_key=lambda val: f"seed{val}"),
+
+        hyperparam("--log-format", "json"),
+        hyperparam("--log-interval", 10),
+    ]
+```
+
+Each `hyperparam(...)` corresponds to a separate command-line flag with the following structure:
+```python
+hyperparam(
+    "--flag",  # command-line flag corresponding to this hyperparameter
+    [0.01, 0.03, 0.1, 0.3, 1.0],  # a list of possible values to sweep over for this hyperparam
+    save_dir_key=lambda val: f"flag{val}",  # map the hyperparam name/value to a directory name
+)
+```
+
+The sweep script will use `save_dir_key` to map each hyperparam configuration to a unique directory name, typically under `/checkpoint/$USER/$DATE`.
+
+## Other options to sweep script
+
+- `--num-trials`: how many random hyperparam configurations should be launched (-1 means launch all possible combinations)
+- `--dry-run`: see what slurm commands will be executed (in simulation mode)
+- `--local`: run the command locally instead of submitting to a remote worker via slurm
+- `--num-nodes`: launch job on multiple nodes
+
+
+## Aggregating results into tables
+Given a sweep started on e.g. 2020-12-15, we can tabulate results with
+
+```bash
+~/fairseq-py/fb_sweep/agg_results.py \
+    "/checkpoint/sshleifer/2020-12-15/**/*.log" \
+    --keep-cols loss,ppl,epoch,wps \
+    --csv-path sweep_results.md \
+    --sort-col loss
+```
+to save a table like
+| path                    |   loss |     ppl |   epoch |    wps |
+|:------------------------|-------:|--------:|--------:|-------:|
+| dummylr.lr_0.0001.ngpu1 |  11.29 | 2504.39 |       1 | 7181   |
+| dummylr.lr_0.0003.ngpu1 |  11.87 | 3743.49 |       1 | 7148.9 |
+| dummylr.lr_3e-05.ngpu1  |  13.1  | 8811.4  |       1 | 7123.1 |
+
+to `sweep_results.md`. To modify the table creation logic you should edit
+[`agg_results.py`](./agg_results.py). Also note that passing `--csv-path xx.csv` will save a csv.
+
+# Using Hydra
+The benefits of Hydra are discussed in detail [here](../docs/hydra_integration.md).
+
+Here is an example parameter sweep with hydra and the `submitit_slurm` launcher.
+This trains language models for 50 steps once for each comma separated parameter value.
+
+First, [install hydra-fair-plugins](https://github.com/fairinternal/hydra-fair-plugins#installation).
+Then, you can run:
+
+
+```bash
+python fairseq_cli/hydra_train.py \
+    --multirun hydra/launcher=submitit_slurm \
+    hydra.launcher.gpus_per_node=1 hydra.launcher.tasks_per_node=1 \
+    distributed_training.distributed_port=33333 \
+    distributed_training.distributed_world_size=1 \
+    hydra.launcher.partition=dev \
+    optimization.max_update=50 \
+    task=dummy_lm model=transformer_lm/transformer_lm_gpt \
+    optimizer=adam \
+    task.tokens_per_sample=512 dataset.batch_size=8 \
+    optimization.lr='[0.0001],[.0003]' \
+    common.log_format=json \
+    common.log_interval=1  common.fp16=True \
+    checkpoint.no_save_optimizer_state=True
+```
+
++ Note that you might need to prepend `PYTHONPATH=.` to the previous command.
+
+Since the only comma separated parameter value is `optimization.lr='[0.0001],[.0003]'`, two models will be trained.
+If we specified `optimizer=adam,sgd`, four models would be trained.
+
+Before submitting jobs to slurm, we can debug locally by changing `--multirun hydra/launcher=submitit_local`.
+
+
+### Monitor Training Logs
+The command above (and all multirun commands) produce a message then wait until jobs are finished.
+
+The first line of the command will show where in your `devfair` file system we will need to look:
+For example,
+```
+[2020-11-24 09:52:52,463][HYDRA] Submitit 'slurm' sweep output dir : multirun/2020-11-24/09-52-49
+```
+
+We can then run `tree -Ra multirun/2020-11-24/09-52-49/` to see all the files being generated, and
+
+```bash
+ls multirun/2020-11-24/09-52-49/.submitit/**/*.out | xargs tail -n 2
+```
+to monitor progress of each job.
+
+To compile results into a table, you can use fb_sweep/agg_results.py, for example:
+
+```bash
+~/fairseq-py/fb_sweep/agg_results.py \
+    "multirun/2020-11-24/09-52-49/**/.submitit/**/*.out" \
+    --csv-path hydra_agg.md \
+    -keep-cols=ppl,wps,epoch,date
+```
+Will produce warnings for jobs that haven't started, and make a table like below once jobs start logging
+
+|       path |   ppl |    wps |   epoch | date                |
+|-----------:|------:|-------:|--------:|:--------------------|
+| 33172726_0 |  6.52 | 1440.2 |       1 | 2020-11-24-09-52-49 |
+| 33172726_1 |  3.64 | 1401.8 |       1 | 2020-11-24-09-52-49 |
+
+
+
+### Discover launcher options
+```bash
+python fairseq_cli/hydra_train.py hydra/launcher=submitit_slurm --cfg hydra -p hydra.launcher
+```
+These launcher options are similar to the command line args accepted by scripts in `fb_sweep/`.

--- a/fb_sweep/sweep/__init__.py
+++ b/fb_sweep/sweep/__init__.py
@@ -1,0 +1,340 @@
+import argparse
+import datetime
+import os
+import socket
+from typing import List, Optional
+
+
+def csv_str_list(x):
+    return [y.strip() for y in x.split(",")]
+
+
+def get_args(add_extra_options_func=None, input_args: Optional[List[str]] = None):
+    """
+    input_args (List[str]): strings to parse, defaults to sys.argv
+    """
+    parser = argparse.ArgumentParser("Script for launching hyperparameter sweeps ")
+    parser.add_argument("--grid", help="grid function we used", default=None)
+    parser.add_argument("--pair", help="language direction", default=None)
+
+    parser.add_argument("-d", "--data", help="path to data directory")
+    parser.add_argument(
+        "-p",
+        "--prefix",
+        required=True,
+        help="save checkpoints and logs in <checkpoints-dir>/<prefix>.<save_dir_key>",
+    )
+    parser.add_argument(
+        "-t",
+        "--num-trials",
+        required=True,
+        type=int,
+        help="number of random hyperparam configurations to try (-1 for grid search)",
+    )
+    parser.add_argument(
+        "-g", "--num-gpus", type=int, required=True, help="number of GPUs per node"
+    )
+    parser.add_argument(
+        "-n",
+        "--num-nodes",
+        type=int,
+        default=1,
+        help="number of nodes for distributed training",
+    )
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument(
+        "--baseline-model", help="path to baseline model from which to resume training"
+    )
+    parser.add_argument(
+        "--force-checkpoints-dir", help="force using a given checkpoint dir"
+    )
+    parser.add_argument(
+        "--resume-failed",
+        action="store_true",
+        help="resume any runs that failed (assumes --num-trials and --seed are the same)",
+    )
+    parser.add_argument(
+        "--resume-finished",
+        action="store_true",
+        help="force any runs that finished to begin again (uncommon)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="output only a list of actions to perform without performing them",
+    )
+    parser.add_argument("--local", action="store_true", help="run job locally")
+    parser.add_argument("--debug", action="store_true", help="debug")
+    parser.add_argument("--script", default="train.py", help="script to launch")
+    parser.add_argument(
+        "--python", default="python", help="path to nonstandard python binary"
+    )
+
+    try:
+        import torch_xla  # noqa
+
+        tpu = True
+    except ImportError:
+        tpu = False
+
+    hostname = socket.gethostname()
+    if "fair" in hostname:
+        default_backend = "slurm"
+        parser.add_argument(
+            "--checkpoints-dir",
+            default=os.path.join(
+                "/checkpoint", os.environ["USER"], str(datetime.date.today())
+            ),
+            help="save checkpoints and logs in <checkpoints-dir>/<prefix>.<save_dir_key>",
+        )
+    elif tpu:
+        default_backend = "tpu"
+        parser.add_argument(
+            "--checkpoints-dir",
+            default=os.path.join(
+                "/mnt/fairseq_data",
+                os.environ["USER"],
+                "checkpoints",
+                str(datetime.date.today()),
+            ),
+            help="save checkpoints and logs in <checkpoints-dir>/<prefix>.<save_dir_key>",
+        )
+    else:
+        default_backend = "fblearner"
+        parser.add_argument(
+            "--checkpoints-dir",
+            default=os.path.join(
+                "/mnt/vol/gfsai-east/ai-group/users",
+                os.environ["USER"],
+                "checkpoints",
+                str(datetime.date.today()),
+            ),
+            help="save checkpoints and logs in <checkpoints-dir>/<prefix>.<save_dir_key>",
+        )
+        parser.add_argument(
+            "--log-main-dir",
+            default=None,
+            help="dir to store log in addition to stdout. If this "
+            "is not set, it will be set to args.checkpoints_dir",
+        )
+
+    parser.add_argument(
+        "--backend",
+        choices=["fblearner", "chronos", "slurm", "tpu"],
+        default=default_backend,
+    )
+
+    # FBLearner params
+    parser.add_argument("--entitlement", help="entitlement to use", default="gpu_fair")
+    parser.add_argument(
+        "--run-as-secure-group", help="secure group to use", default="oncall_fairseq"
+    )
+    parser.add_argument(
+        "--capabilities",
+        help="capabilities: e.g. GPU_V100_HOST,GPU_V100_32G_HOST",
+        type=csv_str_list,
+        default=None,
+    )
+    # for manifold in fblearner
+    parser.add_argument(
+        "--manifold-max-parallel",
+        default=8,
+        type=int,
+        help="set ManifoldPathHandler max_parallel download number",
+    )
+    parser.add_argument(
+        "--manifold-timeout-sec",
+        default=1800,
+        type=int,
+        help="set ManifoldPathHandler timeout seconds",
+    )
+    parser.add_argument(
+        "--manifold-has-user-data",
+        default=None,
+        type=lambda x: x.lower() not in ("no", "false", "f", "n", "0")
+        if x is not None
+        else None,
+        help="set ManifoldPathHandler has_user_data option",
+    )
+    parser.add_argument(
+        "--manifold-num-retries",
+        default=15,
+        type=int,
+        help="set ManifoldPathHandler num_retries option",
+    )
+    parser.add_argument(
+        "--manifold-ttl",
+        default=None,
+        type=int,
+        help="A manifold  resource's time-to-live, applied to all manifold written resources. By default, there is no TTL.",
+    )
+    # for manifold in fblearner
+
+    # Chronos params
+    parser.add_argument("--hostgroup", help="hostgroup to use")
+    parser.add_argument("--host-filter", help="host filter")
+    parser.add_argument("--fbpkg", help="use the given fbpkg")
+    parser.add_argument("--build-only", action="store_true")
+
+    # Slurm params
+    parser.add_argument(
+        "--salloc", action="store_true", help="run agaist current allocation"
+    )
+    parser.add_argument("--partition", help="partition to run on", default="learnfair")
+    parser.add_argument("--reservation", help="reservation to run on")
+    parser.add_argument(
+        "--exclusive", action="store_true", help="if set, get exclusive host"
+    )
+    parser.add_argument(
+        "--dep",
+        metavar="JOBID",
+        type=int,
+        help="add JOBID as a dependency (i.e., wait for it to finish)",
+    )
+    parser.add_argument(
+        "--sequential", action="store_true", help="schedule jobs to run sequentially"
+    )
+    parser.add_argument(
+        "--time", default="4320", help="expected job duration in minutes"
+    )
+    parser.add_argument("--mem", "--mem", help="memory to request")
+    parser.add_argument(
+        "--constraint",
+        metavar="CONSTRAINT",
+        help='gpu constraint, if any. e.g. "volta"',
+    )
+    parser.add_argument("--comment", help="comment string")
+    parser.add_argument(
+        "--snapshot-code",
+        action="store_true",
+        default=False,
+        help="Flag for creating a snapshot of training code while creating slurm job,"
+        ' path is "./slurm_snapshot_code/<TIME_ISO_FORMAT/>:", '
+        "can find time from comment of slurm job.",
+    )
+    parser.add_argument(
+        "--snapshot-root",
+        type=str,
+        default=".",
+        help="root path for saving the snapshot code.",
+    )
+    parser.add_argument(
+        "--snapshot-recurse-dirs",
+        default="fairseq,fairseq_cli",
+        help="comma-separated directories from where to recursively copy *.py, *.so and *.yaml files",
+    )
+    parser.add_argument(
+        "--tensorboard-logdir",
+        help="save tensorboard logs in <tensorboard-logdir>/<prefix>.<save_dir_key>",
+    )
+    parser.add_argument(
+        "--no-tensorboard", action="store_true", help="disable tensorboard logging"
+    )
+    parser.add_argument("--no-wandb", action="store_true", help="disable WandB logging")
+    parser.add_argument(
+        "--post-steps",
+        nargs="+",
+        help="additional steps to execute after the primary job is complete. "
+        "this can be a file with the steps, or a string. some placeholders such as "
+        "{job_dir} will be replaced",
+    )
+    parser.add_argument(
+        "--use-jobarray", action="store_true", help="Submit sweep as job-array"
+    )
+    parser.add_argument(
+        "--jobarray-name",
+        type=str,
+        default=None,
+        help="Folder name for job-array. Defaults to <jobarray_timestamp>",
+    )
+
+    # GCP params
+    parser.add_argument("--tpu", help="tpu to use")
+
+    if add_extra_options_func is not None:
+        add_extra_options_func(parser)
+    args = parser.parse_args(input_args)
+    if args.use_jobarray:
+        if args.jobarray_name is None:
+            ja_hash = datetime.datetime.now().isoformat().replace(":", "_")
+            args.jobarray_name = f"jobarray_{ja_hash}"
+        assert not args.local, "Job array should not be local"
+        assert not args.sequential, "Cannot have both sequential and jobarray"
+    return args
+
+
+class hyperparam(object):
+    """Base class for defining hyperparameters."""
+
+    def __init__(
+        self,
+        name,
+        values=None,
+        binary_flag=False,
+        save_dir_key=None,
+        positional_arg=False,
+    ):
+        """
+        Arguments:
+        - name : the name of the hyperparameter (e.g., `--dropout`)
+        - values : the set of values to sweep over (e.g., `[0.0, 0.1, 0.2]`)
+        - binary_flag : whether the hyperparameter uses a boolean flag (e.g., `--no-save`)
+        - save_dir_key : function that takes the hyperparameter value and returns the "key"
+                         to be appended to the output directory name
+        - positional_arg : whether the hyperparameter is a positional argument
+        """
+        self.name = name
+        if values is None:  # syntactic sugar for binary flags
+            self.values = [True]
+            self.binary_flag = True
+        else:
+            self.values = values if isinstance(values, list) else [values]
+            self.binary_flag = binary_flag
+        self.save_dir_key = save_dir_key
+        self.positional_arg = positional_arg
+        self.current_value = None
+
+        if positional_arg and name.startswith("-"):
+            raise ValueError(
+                f"positional arguments must not start with a dash ({name})"
+            )
+
+        if len(self.values) > 1 and self.save_dir_key is None:
+            raise ValueError(
+                f"{name} has more than one value but is missing a save_dir_key!"
+            )
+
+    def get_cli_args(self):
+        if self.binary_flag:
+            return [self.name] if self.current_value else []
+        elif self.positional_arg:
+            return [self.current_value]
+        else:
+            return [self.name, self.current_value]
+
+    def get_save_dir_key(self):
+        if self.save_dir_key is None:
+            return None
+        if self.binary_flag:
+            return self.save_dir_key(1) if self.current_value else None
+        return self.save_dir_key(self.current_value)
+
+
+def main(
+    get_grid,
+    postprocess_hyperparams,
+    add_extra_options_func=None,
+    scheduler_args: Optional[List[str]] = None,
+):
+    args = get_args(add_extra_options_func, scheduler_args)
+    if args.backend == "fblearner":
+        from .fblearner import main as backend_main
+    elif args.backend == "chronos":
+        from .chronos import main as backend_main
+    elif args.backend == "slurm":
+        from .slurm import main as backend_main
+    elif args.backend == "tpu":
+        from .tpu import main as backend_main
+
+    get_grid = get_grid[args.grid] if args.grid is not None else get_grid
+    backend_main(get_grid, postprocess_hyperparams, args)

--- a/fb_sweep/sweep/chronos.py
+++ b/fb_sweep/sweep/chronos.py
@@ -1,0 +1,326 @@
+import itertools
+import os
+import random
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from collections import OrderedDict
+
+import libfb.py.fbpkg as fbpkg
+
+
+def main(get_grid, postprocess_hyperparams, args):
+    assert args.hostgroup is not None, "--hostgroup is required for Chronos jobs"
+
+    # compute all possible hyperparameter configurations
+    grid = get_grid(args)
+    grid_product = list(itertools.product(*[hp.values for hp in grid]))
+
+    # randomly shuffle configurations
+    random.seed(args.seed)
+    random.shuffle(grid_product)
+
+    # build train fbpkg
+    if not args.local and args.fbpkg is not None:
+        train_fbpkg = args.fbpkg
+    else:
+        # build train.par
+        if args.debug:
+            mode = "dbg"
+        elif args.local:
+            mode = "dev-nosan"
+        else:
+            mode = "opt"
+        buck_cmd = [
+            "/usr/local/bin/buck",
+            "build",
+            "@mode/" + mode,
+            "deeplearning/projects/fairseq-py:fb_train",
+        ]
+        buck_cmd_str = " ".join(map(shlex.quote, buck_cmd))
+        if args.dry_run:
+            print(f"| dry-run: {buck_cmd_str}")
+        else:
+            subprocess.Popen(
+                buck_cmd,
+                cwd=os.path.join(
+                    "/data/users",
+                    os.environ["USER"],
+                    "fbsource/fbcode",
+                ),
+            ).wait()
+
+        if args.dry_run:
+            print(f"| dry_run: build fbpkg")
+        elif args.local:
+            train_fbpkg = None
+        else:
+            train_fbpkg = fbpkg.build_version(
+                "fairseq",
+                build_config=fbpkg.BuildConfig(
+                    paths=[
+                        os.path.join(
+                            "/data/users",
+                            os.environ["USER"],
+                            "fbsource/fbcode",
+                            "buck-out/gen/deeplearning/projects/fairseq-py/fb_train.par",
+                        )
+                    ],
+                ),
+                ephemeral=True,
+                expire="2w",
+            )[0].identifier
+
+        if args.build_only:
+            sys.exit(0)
+
+    if args.dry_run:
+        train_fbpkg = "fb_train.par"
+
+    for i, hp_values in enumerate(grid_product):
+        config = OrderedDict()
+        for hp, value in zip(grid, hp_values):
+            config[hp.name] = hp
+            config[hp.name].current_value = value
+
+        # postprocess hyperparams
+        postprocess_hyperparams(args, config)
+
+        # launch training
+        launch_train(args, config, train_fbpkg)
+
+        if i == args.num_trials - 1:
+            break
+
+
+def launch_train(args, config, train_fbpkg):
+    def dry_run(msg):
+        if args.dry_run:
+            print(f"| dry-run: {msg}")
+        return args.dry_run
+
+    # compute save_dir
+    save_dir_key = ".".join(
+        filter(
+            lambda save_dir_key: save_dir_key is not None,
+            [hp.get_save_dir_key() for hp in config.values()],
+        )
+    )
+    save_dir_key = save_dir_key.replace(",", "_")
+    num_total_gpus = args.num_nodes * args.num_gpus
+    x = int(time.time())
+    if not args.force_checkpoints_dir:
+        save_dir = os.path.join(
+            args.checkpoints_dir,
+            f"{args.prefix}.{save_dir_key}.ngpu{num_total_gpus}.{x}",
+        )
+    else:
+        save_dir = args.force_checkpoints_dir
+
+    # create save directory if it doesn't exist
+    if not os.path.exists(save_dir):
+        if not dry_run(f"create directory: {save_dir}"):
+            os.makedirs(save_dir)
+            os.chmod(save_dir, 0o777)
+
+    # if has_started(save_dir) and not args.resume_checkpoints_dir:
+    #    print(f'skip in progress run: {save_dir}')
+    #    return
+
+    # generate train command
+    cmd_args = []
+    if args.data:
+        cmd_args += [args.data]
+    cmd_args += ["--save-dir", save_dir]
+    for hp in config.values():
+        cmd_args.extend(map(str, hp.get_cli_args()))
+    cmd_args_str = " ".join(map(shlex.quote, cmd_args))
+    if args.dry_run:
+        dry_run(f"train command: fb_train.par {cmd_args_str}")
+
+    # initialize train log
+    train_log = os.path.join(save_dir, "train.log")
+    if not dry_run(f"create train.log at: {train_log}"):
+        with open(train_log, "a") as train_log_h:
+            train_log_h.write("")
+        os.chmod(train_log, 0o777)
+
+    # write script
+    script = get_script(
+        port=get_random_port(),
+        world_size=(args.num_nodes * args.num_gpus),
+        train_fbpkg=train_fbpkg,
+        cmd_args_str=cmd_args_str,
+        stdout=train_log,
+        stderr_prefix=os.path.join(save_dir, "train.stderr"),
+        baseline_model_src=args.baseline_model,
+        baseline_model_dst=os.path.join(save_dir, "checkpoint_last.pt"),
+    )
+    with tempfile.NamedTemporaryFile("w") as h:
+        if not dry_run(f"write script to: {h.name}\n\n{script}"):
+            h.write(script)
+            h.flush()
+
+        # crun
+        crun_cmd = [
+            "/usr/local/chronos/scripts/crun",
+            "--print-url",
+            "--mailwhen",
+            "onFailure",
+            "--hostgroup",
+            str(args.hostgroup),
+            "--gang-size",
+            str(args.num_nodes),
+            "-G",
+            str(args.num_gpus),
+            "-C",
+            str(10 * args.num_gpus),
+            "-M",
+            ("-1" if args.num_gpus == 8 else str(29 * args.num_gpus)),
+            #'--host-filter', 'gpu_model=="Tesla V100-SXM2-16GB"',
+            h.name,
+        ]
+        crun_cmd_str = " ".join(map(shlex.quote, crun_cmd))
+
+        env = os.environ.copy()
+        if args.local:
+            assert (
+                args.num_nodes == 1
+            ), "distributed training cannot be combined with --local"
+            if not dry_run("start training locally"):
+                if "CUDA_VISIBLE_DEVICES" not in env:
+                    env["CUDA_VISIBLE_DEVICES"] = ",".join(
+                        map(str, range(args.num_gpus))
+                    )
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    os.chmod(tmpdir, 0o777)
+                    subprocess.Popen(
+                        [
+                            os.path.join(
+                                "/data/users",
+                                os.environ["USER"],
+                                "fbsource/fbcode",
+                                "buck-out/gen/deeplearning/projects/fairseq-py/fb_train.par",
+                            )
+                        ]
+                        + cmd_args,
+                        env=env,
+                        cwd=tmpdir,
+                    ).wait()
+        else:
+            if args.dry_run:
+                print("| dry-run: start remote training")
+                print(f"| dry-run: - run command: {crun_cmd_str}")
+            else:
+                subprocess.Popen(crun_cmd).wait()
+
+    return train_log
+
+
+def get_script(
+    port,
+    world_size,
+    train_fbpkg,
+    cmd_args_str,
+    stdout,
+    stderr_prefix,
+    baseline_model_src,
+    baseline_model_dst,
+):
+    if baseline_model_src is not None:
+        link_baseline = f"""
+        if [ ! -e {baseline_model_dst} ]; then
+            cp {baseline_model_src} {baseline_model_dst}.tmp
+            mv {baseline_model_dst}.tmp {baseline_model_dst}
+        fi
+        """
+        wait_baseline = f"""
+        while [ ! -e {baseline_model_dst} ]; do
+            sleep 5
+        done
+        """
+    else:
+        link_baseline = ":"
+        wait_baseline = ":"
+
+    node_size = world_size if world_size < 8 else 8
+
+    if world_size > 1:
+        distributed = """\
+        --distributed-init-method zeus://$CHRONOS_JOB_ID \
+        --distributed-world-size $WORLD_SIZE \
+        --distributed-rank $RANK
+        """
+    else:
+        distributed = ""
+
+    save_dir = os.path.dirname(baseline_model_dst)
+
+    return f"""#!/bin/bash
+/usr/local/bin/fbpkg fetch {train_fbpkg}
+
+#if [ $(nvidia-smi | grep "No running processes found" | wc -l) != "1" ]; then
+#    echo "Error: there are other running GPU processes"
+#    exit 1
+#fi
+
+export MASTER_ADDR=$(/usr/local/chronos/scripts/clist -F name,hostname -n | grep $(echo $CHRONOS_JOB_NAME | sed "s/_GANG_MEMBER$//") | cut -d' ' -f 3).facebook.com
+export MASTER_PORT={port}
+export WORLD_SIZE={world_size}
+export RANK=$(({node_size}*CHRONOS_GANG_MEMBER_ID))
+
+echo MASTER_ADDR: $MASTER_ADDR
+echo MASTER_PORT: $MASTER_PORT
+echo WORLD_SIZE: $WORLD_SIZE
+echo RANK: $RANK
+
+export NCCL_DEBUG=INFO
+export NCCL_MIN_NRINGS=8
+export NCCL_NSOCKS_PERTHREAD=1
+export NCCL_SOCKET_NTHREADS=4
+export NCCL_BUFFSIZE=16777216 
+
+# disable trees
+export NCCL_TREE_THRESHOLD=0
+
+## disable libgpumon
+#export CUDA_INJECTION64_PATH=none
+
+nvidia-smi
+
+export
+
+ulimit -a
+
+ifconfig
+
+ping6 -c 5 $MASTER_ADDR
+
+if [ $RANK -eq 0 ]; then
+    {link_baseline}
+else
+    {wait_baseline}
+fi
+
+mkdir -p {save_dir}
+chmod 777 {save_dir}
+
+LD_LIBRARY_PATH=/mnt/vol/gfsai-flash3-east/ai-group/users/myleott/nccl_2.4.8-1:$LD_LIBRARY_PATH ./fb_train.par {cmd_args_str} {distributed}
+"""
+
+
+def has_started(save_dir):
+    train_log = os.path.join(save_dir, "train.log")
+    if not os.path.exists(train_log):
+        return False
+    return True
+
+
+def get_random_port():
+    old_state = random.getstate()
+    random.seed()
+    port = random.randint(10000, 20000)
+    random.setstate(old_state)
+    return port

--- a/fb_sweep/sweep/fblearner.py
+++ b/fb_sweep/sweep/fblearner.py
@@ -1,0 +1,272 @@
+import itertools
+import json
+import os
+import random
+import shlex
+import shutil
+import subprocess
+import tempfile
+from collections import OrderedDict
+
+from fairseq.file_io import PathManager
+
+
+def main(get_grid, postprocess_hyperparams, args):
+    if args.manifold_has_user_data is None:
+        raise ValueError(
+            "fblearner backend requires --manifold-has-user-data be specified explicitly"
+        )
+    try:
+        from iopath.fb.manifold import ManifoldPathHandler
+
+        PathManager.register_handler(
+            ManifoldPathHandler(
+                max_parallel=16,
+                timeout_sec=1800,
+                has_user_data=args.manifold_has_user_data,
+            )
+        )
+    except KeyError:
+        print("| ManifoldPathHandler already registered.")
+    # compute all possible hyperparameter configurations
+    grid = get_grid(args)
+    grid_product = list(itertools.product(*[hp.values for hp in grid]))
+
+    # randomly shuffle configurations
+    random.seed(args.seed)
+    random.shuffle(grid_product)
+
+    sweep_config = {}
+    save_dirs = []
+    for i, hp_values in enumerate(grid_product):
+        config = OrderedDict()
+        for hp, value in zip(grid, hp_values):
+            config[hp.name] = hp
+            config[hp.name].current_value = value
+
+        # postprocess hyperparams
+        postprocess_hyperparams(args, config)
+
+        # setup training
+        x = setup_train(args, config)
+        if x is not None:
+            cmd_args = x["cmd_args"]
+            cmd_args.extend(
+                [
+                    "--manifold-max-parallel",
+                    str(args.manifold_max_parallel),
+                    "--manifold-timeout-sec",
+                    str(args.manifold_timeout_sec),
+                    "--manifold-has-user-data",
+                    str(args.manifold_has_user_data),
+                    "--manifold-num-retries",
+                    str(args.manifold_num_retries),
+                ]
+            )
+            if args.manifold_ttl is not None:
+                cmd_args.extend(
+                    [
+                        "--manifold-ttl",
+                        str(args.manifold_ttl),
+                    ]
+                )
+            if args.tensorboard_logdir:
+                cmd_args.extend(
+                    [
+                        "--tensorboard-logdir",
+                        args.tensorboard_logdir,
+                        "--tensorboard-manifold",
+                    ]
+                )
+            sweep_config[x["train_log_path"]] = cmd_args
+            save_dirs.append(x["save_dir"])
+
+        if i == args.num_trials - 1:
+            break
+
+    if len(save_dirs) == 0:
+        return
+
+    with tempfile.NamedTemporaryFile("w") as h:
+        config = {
+            "cmd_args": [],
+            "num_nodes": args.num_nodes,
+            "num_gpus_per_node": args.num_gpus,
+            "fp16": any(
+                "--fp16" in cmd_args or "--memory-efficient-fp16" in cmd_args
+                for cmd_args in sweep_config.values()
+            ),
+            "sweep_config": sweep_config,
+            "gang_affinity": False,
+            "capabilities": getattr(args, "capabilities", None),
+            "memory": int(args.mem) if args.mem is not None else None,
+        }
+        h.write(json.dumps(config))
+        h.flush()
+
+        # build flow command
+        prefix = args.prefix.rstrip("_")
+        num_total_gpus = args.num_nodes * args.num_gpus
+        flow_cmd = [
+            "/usr/local/bin/flow-cli",
+            "canary",
+            #'--py-version', '>=3',
+            "--mode",
+            "opt",
+            "--entitlement",
+            str(args.entitlement),
+            "--run-as-secure-group",
+            args.run_as_secure_group,
+            "--parameters-file",
+            str(h.name),
+            "--name",
+            f"{prefix}.ngpu{num_total_gpus}",
+            "fairseq.train.train_workflow"
+            # TODO put stuff in --notes, e.g., repro command
+        ]
+
+        cmd = " ".join(map(shlex.quote, flow_cmd))
+
+        if args.dry_run:
+            print("| dry-run: start remote training")
+            print(f"| dry-run: - run command: {cmd}")
+        else:
+            subprocess.Popen(
+                flow_cmd,
+                cwd=os.path.join(
+                    "/data/users",
+                    os.environ["USER"],
+                    "fbsource/fbcode",
+                ),
+            ).wait()
+
+
+def setup_train(args, config):
+    def dry_run(msg):
+        if args.dry_run:
+            print(f"| dry-run:  {msg}")
+        return args.dry_run
+
+    # compute save_dir
+    save_dir_key = ".".join(
+        filter(
+            lambda save_dir_key: save_dir_key is not None,
+            [hp.get_save_dir_key() for hp in config.values()],
+        )
+    )
+    save_dir_key = save_dir_key.replace(",", "_")
+    num_total_gpus = args.num_nodes * args.num_gpus
+
+    subdir_name = f"{args.prefix}.{save_dir_key}.ngpu{num_total_gpus}"
+    save_dir = os.path.join(args.checkpoints_dir, subdir_name)
+    log_main_dir = (
+        args.log_main_dir if args.log_main_dir is not None else args.checkpoints_dir
+    )
+    log_dir = os.path.join(log_main_dir, subdir_name)
+
+    # create save directory if it doesn't exist
+    if not os.path.exists(save_dir):
+        if not dry_run(f"create directory: {save_dir}"):
+            PathManager.mkdirs(save_dir)
+            PathManager.chmod(save_dir, 0o777)
+
+        # copy baseline model
+        checkpoint_last = os.path.join(save_dir, "checkpoint_last.pt")
+        if (
+            args.baseline_model
+            and not os.path.exists(checkpoint_last)
+            and not dry_run(f"initialize with baseline model: {args.baseline_model}")
+        ):
+            if not os.path.exists(args.baseline_model):
+                raise FileNotFoundError(
+                    f"Cannot find baseline model: {args.baseline_model}"
+                )
+            shutil.copyfile(args.baseline_model, checkpoint_last)
+
+    # TODO make this work
+    # check for whether the run failed
+    # if has_finished(save_dir):
+    #    if args.resume_finished:
+    #        dry_run(f'restart previously finished run: {save_dir}')
+    #    else:
+    #        print(f'skip finished run (override with --resume-finished): {save_dir}')
+    #        return
+    # elif has_failed(save_dir):
+    #    if args.resume_failed:
+    #        dry_run(f'resume failed run: {save_dir}')
+    #    else:
+    #        print(f'skip failed run (override with --resume-failed): {save_dir}')
+    #        return
+    # elif has_started(save_dir):
+    if has_started(log_dir) and not (args.resume_finished or args.resume_failed):
+        # if not resume previous runs explicitly, take it as started
+        print(f"skip in progress run: {log_dir}")
+        return
+
+    # generate train command
+    cmd_args = [args.data, "--save-dir", save_dir, "--log-dir", log_dir]
+    for hp in config.values():
+        cmd_args.extend(map(str, hp.get_cli_args()))
+    if args.dry_run:
+        cmd_args_str = " ".join(cmd_args)
+        dry_run(f"train command: train.par {cmd_args_str}")
+
+    # initialize train log
+    train_log = os.path.join(log_dir, "train.log")
+    if not dry_run(f"create train.log at: {train_log}"):
+        PathManager.mkdirs(log_dir)
+        PathManager.chmod(log_dir, 0o777)
+        with PathManager.open(train_log, "a") as train_log_h:
+            train_log_h.write("")
+        PathManager.chmod(train_log, 0o777)
+
+    return {
+        "cmd_args": cmd_args,
+        "save_dir": save_dir,
+        "save_dir_key": save_dir_key,
+        "train_log_path": train_log,
+    }
+
+
+# def has_finished(save_dir):
+#    train_log = os.path.join(save_dir, 'train.log')
+#    if not os.path.exists(train_log):
+#        return False
+#    with open(train_log, 'r') as h:
+#        lines = h.readlines()
+#        if len(lines) == 0:
+#            return False
+#        if 'done training' in lines[-1]:
+#            return True
+#    return False
+#
+#
+# def has_failed(save_dir):
+#    if not os.path.exists(save_dir):
+#        return False
+#
+#    # find max job id
+#    job_ids = []
+#    for fn in os.listdir(save_dir):
+#        if fn.startswith('train.stderr.'):
+#            job_ids.append(int(fn.split('.')[-1]))
+#    if len(job_ids) == 0:
+#        return False
+#    max_job_id = max(job_ids)
+#
+#    def _has_failed(stderr_fn):
+#        with open(stderr_fn, 'r') as h:
+#            for line in h:
+#                if len(line.strip()) > 0:
+#                    # assume that any output in stderr indicates an error
+#                    return True
+#        return False
+#
+#    return _has_failed(os.path.join(save_dir, f'train.stderr.{max_job_id}'))
+
+
+def has_started(log_dir):
+    train_log = os.path.join(log_dir, "train.log")
+    if not os.path.exists(train_log):
+        return False
+    return True

--- a/fb_sweep/sweep/slurm.py
+++ b/fb_sweep/sweep/slurm.py
@@ -1,0 +1,591 @@
+import datetime
+import hashlib
+import itertools
+import os
+import random
+import shlex
+import shutil
+import subprocess
+import textwrap
+from collections import OrderedDict
+from glob import iglob
+
+BASH_IF_CLAUSE = """
+if [ "$SLURM_ARRAY_TASK_ID" = "{index}" ]; then
+    {srun_cmd}
+fi
+"""
+
+
+def main(get_grid, postprocess_hyperparams, args):
+    def dry_run(msg):
+        if args.dry_run:
+            print(f"| dry-run:  {msg}")
+        return args.dry_run
+
+    if args.local:
+        args.num_nodes = 1
+
+    # compute all possible hyperparameter configurations
+    grid = get_grid(args)
+    grid_product = list(itertools.product(*[hp.values for hp in grid]))
+
+    # randomly shuffle configurations
+    random.seed(args.seed)
+    random.shuffle(grid_product)
+
+    launch_train(args, grid, grid_product, dry_run, postprocess_hyperparams)
+
+
+def copy_all_python_files(
+    source, snapshot_main_dir, code_snapshot_hash, recurse_dirs="fairseq"
+):
+    """
+    Copies following files from source to destination:
+        a) all *.py files at direct source location.
+        b) all fairseq/*.py recursively (default); recurse through comma-separated recurse_dirs
+    """
+
+    def all_pys(recurse_dirs):
+        yield from iglob(os.path.join(source, "*.py"))
+        for d in recurse_dirs.split(","):
+            yield from iglob(os.path.join(source, d, "**/*.py"), recursive=True)
+            yield from iglob(os.path.join(source, d, "**/*.so"), recursive=True)
+            yield from iglob(os.path.join(source, d, "**/*.yaml"), recursive=True)
+
+    os.makedirs(snapshot_main_dir, exist_ok=True)
+    destination = os.path.join(snapshot_main_dir, code_snapshot_hash)
+    assert not os.path.exists(destination), "Code snapshot: {0} alredy exists".format(
+        code_snapshot_hash
+    )
+    os.makedirs(destination)
+
+    for filepath in all_pys(recurse_dirs):
+        directory, filename = os.path.split(filepath)
+        if directory:
+            os.makedirs(os.path.join(destination, directory), exist_ok=True)
+        shutil.copy2(
+            os.path.join(source, filepath), os.path.join(destination, filepath)
+        )
+    return destination
+
+
+def run_setup(args, config, dry_run):
+    # compute save_dir
+    save_dir_key = ".".join(
+        filter(
+            lambda save_dir_key: save_dir_key is not None,
+            [hp.get_save_dir_key() for hp in config.values()],
+        )
+    )
+    save_dir_key = save_dir_key.replace(",", "_")
+    num_total_gpus = args.num_nodes * args.num_gpus
+    if args.use_jobarray:
+        save_dir = os.path.join(
+            args.checkpoints_dir,
+            args.jobarray_name,
+            f"{args.prefix}.{save_dir_key}.ngpu{num_total_gpus}",
+        )
+    else:
+        save_dir = os.path.join(
+            args.checkpoints_dir, f"{args.prefix}.{save_dir_key}.ngpu{num_total_gpus}"
+        )
+
+    # create save directory if it doesn't exist
+    if not os.path.exists(save_dir):
+        if not dry_run(f"create directory: {save_dir}"):
+            os.makedirs(save_dir)
+
+        # copy baseline model
+        checkpoint_last = os.path.join(save_dir, "checkpoint_last.pt")
+        if (
+            args.baseline_model
+            and not os.path.exists(checkpoint_last)
+            and not dry_run(f"initialize with baseline model: {args.baseline_model}")
+        ):
+            if not os.path.exists(args.baseline_model):
+                raise FileNotFoundError(
+                    f"Cannot find baseline model: {args.baseline_model}"
+                )
+            shutil.copyfile(args.baseline_model, checkpoint_last)
+
+    # create slurm log dir for job arrays
+    if args.use_jobarray:
+        slurm_dir = os.path.join(args.checkpoints_dir, args.jobarray_name, "slurm_logs")
+        if not os.path.exists(slurm_dir):
+            if not dry_run(f"create directory: {slurm_dir}"):
+                os.makedirs(slurm_dir)
+        return save_dir_key, save_dir, slurm_dir
+    else:
+        return save_dir_key, save_dir
+
+
+def is_job_valid(args, save_dir, dry_run):
+    # check for whether the run failed
+    if has_finished(save_dir):
+        if args.resume_finished:
+            dry_run(f"restart previously finished run: {save_dir}")
+        else:
+            print(f"skip finished run (override with --resume-finished): {save_dir}")
+            return False
+    elif has_failed(save_dir):
+        if args.resume_failed:
+            dry_run(f"resume failed run: {save_dir}")
+        else:
+            print(f"skip failed run (override with --resume-failed): {save_dir}")
+            return False
+    elif has_started(save_dir):
+        print(f"skip in progress run: {save_dir}")
+        return False
+    return True
+
+
+def set_env(args, env, dry_run):
+    if "OMP_NUM_THREADS" not in env:
+        env["OMP_NUM_THREADS"] = "2"
+    if args.local:
+        if not dry_run("start training locally"):
+            if "CUDA_VISIBLE_DEVICES" not in env:
+                env["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, range(args.num_gpus)))
+            env["NCCL_DEBUG"] = "INFO"
+    else:
+        if args.num_nodes > 1:
+            env["NCCL_SOCKET_IFNAME"] = "^docker0,lo"
+            env["NCCL_DEBUG"] = "INFO"
+
+
+def gen_train_command(args, env, config, destination, save_dir, save_dir_key):
+    # generate train command
+    train_cmd = [args.python, os.path.join(destination, args.script)]
+    train_cmd.extend(["--distributed-world-size", str(args.num_nodes * args.num_gpus)])
+    if args.num_nodes > 1:
+        train_cmd.extend(
+            [
+                "--distributed-port",
+                str(get_random_port()),
+            ]
+        )
+    if args.data is not None:
+        train_cmd.extend([args.data])
+    train_cmd.extend(["--save-dir", save_dir])
+    if not args.no_tensorboard:
+        _dir = args.tensorboard_logdir
+        if _dir is None:
+            _dir = os.path.join(
+                "/checkpoint",
+                env["USER"],
+                "tensorboard_logs",
+                str(datetime.date.today()),
+            )
+        tensorboard_logdir = os.path.join(
+            _dir,
+            f"{args.prefix}.{save_dir_key}.ngpu{str(args.num_nodes * args.num_gpus)}",
+        )
+        train_cmd.extend(["--tensorboard-logdir", tensorboard_logdir])
+    if not args.no_wandb:
+        if "WANDB_API_KEY" in env and "WANDB_BASE_URL" in env:
+            if "--wandb-project" not in config:
+                project = str(datetime.date.today())
+                train_cmd.extend(["--wandb-project", project])
+            if "WANDB_RUN_GROUP" not in env:
+                env["WANDB_RUN_GROUP"] = args.prefix
+            if "WANDB_RUN_ID" not in env:
+                env["WANDB_RUN_ID"] = hashlib.md5(
+                    os.path.basename(save_dir).encode("utf-8")
+                ).hexdigest()
+    for hp in config.values():
+        train_cmd.extend(map(str, hp.get_cli_args()))
+    return train_cmd
+
+
+def gen_post_commands(args, save_dir):
+    post_cmds = []
+    if args.post_steps:
+        for post_step in args.post_steps:
+            if os.path.isfile(post_step):
+                from pathlib import Path
+
+                post_cmd = Path(post_step).read_text()
+            else:
+                post_cmd = post_step
+            post_cmd = post_cmd.strip().format(
+                job_dir=save_dir
+            )  # assume to provide job_dir
+            post_cmds.append(post_cmd)
+    return post_cmds
+
+
+def gen_srun_command_and_str(
+    args, env, save_dir_key, train_log, train_stderr, train_cmd, post_cmds
+):
+    base_srun_cmd = [
+        "srun",
+        "--job-name",
+        f"{args.prefix}.{save_dir_key}",
+        "--output",
+        train_log,
+        "--error",
+        train_stderr,
+        "--open-mode",
+        "append",
+        "--unbuffered",
+    ]
+    if args.salloc:
+        excluded_hosts = os.environ.get("EXCLUDED_HOSTS", None)
+        included_hosts = os.environ.get("INCLUDED_HOSTS", None)
+        base_srun_cmd += [
+            "--nodes",
+            str(args.num_nodes),
+            "--ntasks",
+            str(args.num_nodes),
+        ]
+        base_srun_cmd += ["-x", excluded_hosts] if excluded_hosts is not None else []
+        base_srun_cmd += ["-w", included_hosts] if included_hosts is not None else []
+
+    srun_cmd = base_srun_cmd + train_cmd
+    srun_cmd_str = " ".join(map(shlex.quote, srun_cmd))
+    for post_cmd in post_cmds:
+        post_cmd_str = " ".join(map(shlex.quote, base_srun_cmd)) + f" {post_cmd}"
+        srun_cmd_str = (
+            f"({srun_cmd_str} && {post_cmd_str})"
+            if len(srun_cmd_str) > 0
+            else post_cmd_str
+        )
+    return srun_cmd, srun_cmd_str
+
+
+def gen_sbatch_command_and_str(
+    args,
+    job_name,
+    train_log,
+    train_stderr,
+    destination,
+    srun_cmd_str,
+    array_length=None,
+):
+    excluded_hosts = os.environ.get("EXCLUDED_HOSTS", None)
+    included_hosts = os.environ.get("INCLUDED_HOSTS", None)
+    sbatch_cmd = [
+        "sbatch",
+        "--job-name",
+        job_name,
+        "--gpus",
+        str(args.num_gpus * args.num_nodes),
+        "--nodes",
+        str(args.num_nodes),
+        "--ntasks-per-node",
+        "1",
+        "--cpus-per-task",
+        str(int(8 * args.num_gpus)),
+        "--output",
+        train_log,
+        "--error",
+        train_stderr,
+        "--open-mode",
+        "append",
+        # '--no-requeue',
+        "--signal",
+        "B:USR1@180",
+    ]
+    if array_length is not None:
+        sbatch_cmd += ["--array", f"0-{array_length-1}"]
+
+    if args.constraint:
+        sbatch_cmd += ["--constraint", args.constraint]
+
+    if args.partition:
+        sbatch_cmd += ["--partition", args.partition]
+    if args.reservation:
+        sbatch_cmd += ["--reservation", args.reservation]
+    if args.exclusive:
+        sbatch_cmd += ["--exclusive"]
+    if args.comment:
+        comment = args.comment
+        if args.snapshot_code:
+            comment += ", Code Location: {0}".format(destination)
+        sbatch_cmd += ["--comment", comment]
+    elif args.snapshot_code:
+        sbatch_cmd += ["--comment", "Code Location: {0}".format(destination)]
+
+    if args.dep is not None:
+        sbatch_cmd.extend(["-d", str(args.dep)])
+    if args.time is not None:
+        sbatch_cmd.extend(["--time", args.time])
+    if args.mem is not None:
+        sbatch_cmd += ["--mem", args.mem]
+    else:
+        sbatch_cmd += ["--mem-per-cpu", "7G"]
+    sbatch_cmd += ["-x", excluded_hosts] if excluded_hosts is not None else []
+    sbatch_cmd += ["-w", included_hosts] if included_hosts is not None else []
+
+    wrapped_cmd = requeue_support() + "\n" + srun_cmd_str
+    if array_length is None:
+        wrapped_cmd = wrapped_cmd + " \n wait $! \n sleep 610 & \n wait $!"
+
+    sbatch_cmd += ["--wrap", wrapped_cmd]
+    sbatch_cmd_str = " ".join(map(shlex.quote, sbatch_cmd))
+    return sbatch_cmd, sbatch_cmd_str
+
+
+def local_run(args, env, train_cmd, post_cmds, dry_run):
+    assert args.num_nodes == 1, "distributed training cannot be combined with --local"
+    if not dry_run("start training locally"):
+        if "CUDA_VISIBLE_DEVICES" not in env:
+            env["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, range(args.num_gpus)))
+        env["NCCL_DEBUG"] = "INFO"
+        train_proc = subprocess.Popen(train_cmd, env=env)
+        train_proc.wait()
+        for post_cmd in post_cmds:
+            post_cmd_proc = subprocess.Popen(post_cmd, shell=True, env=env)
+            post_cmd_proc.wait()
+
+
+def run_batch(env, sbatch_cmd_str, sbatch_cmd):
+    print(f"running command: {sbatch_cmd_str}\n")
+    with subprocess.Popen(sbatch_cmd, stdout=subprocess.PIPE, env=env) as train_proc:
+        stdout = train_proc.stdout.read().decode("utf-8")
+        try:
+            job_id = int(stdout.rstrip().split()[-1])
+            print(f"Launched job {job_id}")
+        except IndexError:
+            job_id = None
+    return job_id, stdout
+
+
+def write_git_commit(args, train_log):
+    with open(train_log, "a") as train_log_h:
+        # log most recent git commit
+        git_commit = subprocess.check_output(
+            "git log | head -n 1", shell=True, encoding="utf-8"
+        )
+        print(git_commit.rstrip(), file=train_log_h)
+        if args.baseline_model:
+            print(f"baseline model: {args.baseline_model}", file=train_log_h)
+
+
+def dry_run_batch(env, train_log, train_stderr, sbatch_cmd_str, sbatch_cmd, dry_run):
+    dry_run("start remote training")
+    dry_run(f"- log stdout to: {train_log}")
+    dry_run(f"- log stderr to: {train_stderr}")
+    dry_run(f"- run command: {sbatch_cmd_str}")
+    sbatch_cmd += ["--test-only"]
+    with subprocess.Popen(sbatch_cmd, stdout=subprocess.PIPE, env=env) as train_proc:
+        stdout = train_proc.stdout.read().decode("utf-8")
+        print(stdout)
+
+
+def launch_train(args, grid, grid_product, dry_run, postprocess_hyperparams):
+    destination = ""
+    if args.snapshot_code:
+        # Currently hash is just the current time in ISO format.
+        # Remove colons since they cannot be escaped in POSIX PATH env vars.
+        code_snapshot_hash = datetime.datetime.now().isoformat().replace(":", "_")
+        destination = copy_all_python_files(
+            ".",
+            os.path.join(args.snapshot_root, "slurm_snapshot_code"),
+            code_snapshot_hash,
+            args.snapshot_recurse_dirs,
+        )
+        os.environ["PYTHONPATH"] = destination + ":" + os.environ.get("PYTHONPATH", "")
+
+    # set environment
+    env = os.environ.copy()
+    set_env(args, env, dry_run)
+
+    # start training
+    srun_cmd_str_list = []
+    train_log_list = []
+    for i, hp_values in enumerate(grid_product):
+        if i == args.num_trials:
+            break
+        config = OrderedDict()
+        for hp, value in zip(grid, hp_values):
+            config[hp.name] = hp
+            config[hp.name].current_value = value
+
+        # postprocess hyperparams
+        postprocess_hyperparams(args, config)
+
+        if args.use_jobarray:
+            save_dir_key, save_dir, slurm_dir = run_setup(args, config, dry_run)
+        else:
+            save_dir_key, save_dir = run_setup(args, config, dry_run)
+
+        # check if job failed, exists, finished
+        if not is_job_valid(args, save_dir, dry_run):
+            continue
+
+        # generate train command
+        train_cmd = gen_train_command(
+            args, env, config, destination, save_dir, save_dir_key
+        )
+
+        # post cmds
+        post_cmds = gen_post_commands(args, save_dir)
+
+        train_log = os.path.join(save_dir, "train.log")
+        train_stderr = os.path.join(save_dir, "train.stderr.%j")  # %j = slurm job id
+        srun_cmd, srun_cmd_str = gen_srun_command_and_str(
+            args, env, save_dir_key, train_log, train_stderr, train_cmd, post_cmds
+        )
+
+        # launch each job individually
+        if not args.use_jobarray:
+            job_id = None
+            if args.dry_run:
+                train_cmd_str = " ".join(train_cmd)
+                dry_run(f"train command: {train_cmd_str}")
+                for post_cmd in post_cmds:
+                    dry_run(f"post steps command: {post_cmd}")
+            if args.local:
+                local_run(args, env, train_cmd, post_cmds, dry_run)
+            else:
+                srun_cmd_str = srun_cmd_str + " &"
+                # build command
+                if not args.salloc:
+                    job_name = f"{args.prefix}.{save_dir_key}"
+                    sbatch_cmd, sbatch_cmd_str = gen_sbatch_command_and_str(
+                        args,
+                        job_name,
+                        train_log,
+                        train_stderr,
+                        destination,
+                        srun_cmd_str,
+                    )
+                else:
+                    sbatch_cmd = srun_cmd
+                    sbatch_cmd_str = srun_cmd_str
+                if args.dry_run:
+                    dry_run_batch(
+                        env,
+                        train_log,
+                        train_stderr,
+                        sbatch_cmd_str,
+                        sbatch_cmd,
+                        dry_run,
+                    )
+                else:
+                    write_git_commit(args, train_log)
+                    with open(train_log, "a") as train_log_h:
+                        job_id, stdout = run_batch(env, sbatch_cmd_str, sbatch_cmd)
+                        print(stdout, file=train_log_h)
+            if job_id is not None:
+                print("Launched {}".format(job_id))
+            if args.sequential and not args.local and job_id is not None:
+                args.dep = job_id
+        else:
+            train_log_list.append(train_log)
+            srun_cmd_str_list.append(srun_cmd_str)
+
+            if not args.dry_run:
+                write_git_commit(args, train_log)
+    # aggregate cmds and launch single job array
+    if args.use_jobarray:
+        aggregate_cmd = ""
+        for i, srun_cmd_str in enumerate(srun_cmd_str_list):
+            aggregate_cmd = aggregate_cmd + BASH_IF_CLAUSE.format(
+                index=i, srun_cmd=srun_cmd_str
+            )
+        job_name = args.jobarray_name
+        slurm_stdout_log = os.path.join(slurm_dir, "slrm_stdout.%j")
+        slurm_stderr_log = os.path.join(slurm_dir, "slrm_stderr.%j")
+        array_length = len(srun_cmd_str_list)
+        sbatch_cmd, sbatch_cmd_str = gen_sbatch_command_and_str(
+            args,
+            job_name,
+            slurm_stdout_log,
+            slurm_stderr_log,
+            destination,
+            aggregate_cmd,
+            array_length=array_length,
+        )
+
+        if args.dry_run:
+            dry_run_batch(
+                env,
+                slurm_stdout_log,
+                slurm_stderr_log,
+                sbatch_cmd_str,
+                sbatch_cmd,
+                dry_run,
+            )
+        else:
+            job_id, stdout = run_batch(env, sbatch_cmd_str, sbatch_cmd)
+            for train_log in train_log_list:
+                with open(train_log, "a") as train_log_h:
+                    print(stdout, file=train_log_h)
+
+
+def has_finished(save_dir):
+    train_log = os.path.join(save_dir, "train.log")
+    if not os.path.exists(train_log):
+        return False
+    with open(train_log, "r") as h:
+        lines = h.readlines()
+        if len(lines) == 0:
+            return False
+        if "done training" in lines[-1]:
+            return True
+    return False
+
+
+def has_failed(save_dir):
+    if not os.path.exists(save_dir):
+        return False
+
+    # find max job id
+    job_ids = []
+    for fn in os.listdir(save_dir):
+        if fn.startswith("train.stderr."):
+            job_ids.append(int(fn.split(".")[-1]))
+    if len(job_ids) == 0:
+        return False
+    max_job_id = max(job_ids)
+
+    def _has_failed(stderr_fn):
+        with open(stderr_fn, "r") as h:
+            for line in h:
+                if len(line.strip()) > 0:
+                    # assume that any output in stderr indicates an error
+                    return True
+        return False
+
+    return _has_failed(os.path.join(save_dir, f"train.stderr.{max_job_id}"))
+
+
+def has_started(save_dir):
+    train_log = os.path.join(save_dir, "train.log")
+    if not os.path.exists(train_log):
+        return False
+    return True
+
+
+def get_random_port():
+    old_state = random.getstate()
+    random.seed()
+    port = random.randint(10000, 20000)
+    random.setstate(old_state)
+    return port
+
+
+def requeue_support():
+    return textwrap.dedent(
+        """
+        trap_handler () {
+           echo "Caught signal: " $1
+           # SIGTERM must be bypassed
+           if [ "$1" = "TERM" ]; then
+               echo "bypass sigterm"
+           else
+             # Submit a new job to the queue
+             echo "Requeuing " $SLURM_JOB_ID
+             scontrol requeue $SLURM_JOB_ID
+           fi
+        }
+
+
+        # Install signal handler
+        trap 'trap_handler USR1' USR1
+        trap 'trap_handler TERM' TERM
+    """
+    )

--- a/fb_sweep/sweep/tpu.py
+++ b/fb_sweep/sweep/tpu.py
@@ -1,0 +1,126 @@
+import itertools
+import os
+import random
+import shlex
+import subprocess
+from collections import OrderedDict
+
+
+def main(get_grid, postprocess_hyperparams, args):
+    assert args.local or args.tpu is not None, "--tpu is required for TPU jobs"
+
+    # compute all possible hyperparameter configurations
+    grid = get_grid(args)
+    grid_product = list(itertools.product(*[hp.values for hp in grid]))
+
+    # randomly shuffle configurations
+    random.seed(args.seed)
+    random.shuffle(grid_product)
+
+    for i, hp_values in enumerate(grid_product):
+        config = OrderedDict()
+        for hp, value in zip(grid, hp_values):
+            config[hp.name] = hp
+            config[hp.name].current_value = value
+
+        # postprocess hyperparams
+        postprocess_hyperparams(args, config)
+
+        # launch training
+        launch_train(args, config)
+
+        if i == args.num_trials - 1:
+            break
+
+
+def launch_train(args, config):
+    def dry_run(msg):
+        if args.dry_run:
+            print(f"| dry-run: {msg}")
+        return args.dry_run
+
+    # compute save_dir
+    save_dir_key = ".".join(
+        filter(
+            lambda save_dir_key: save_dir_key is not None,
+            [hp.get_save_dir_key() for hp in config.values()],
+        )
+    )
+    save_dir_key = save_dir_key.replace(",", "_")
+    num_total_gpus = args.num_nodes * args.num_gpus
+    if args.force_checkpoints_dir:
+        raise NotImplementedError
+    save_dir = os.path.join(
+        args.checkpoints_dir,
+        f"{args.prefix}.{save_dir_key}.ntpu{num_total_gpus}",
+    )
+
+    # create save directory if it doesn't exist
+    if not os.path.exists(save_dir):
+        if not dry_run(f"create directory: {save_dir}"):
+            os.makedirs(save_dir)
+            # os.chmod(save_dir, 0o777)
+
+    # if has_started(save_dir) and not args.resume_checkpoints_dir:
+    #    print(f'skip in progress run: {save_dir}')
+    #    return
+
+    # generate train command
+    cmd_args = [
+        "python",
+        "/mnt/fairseq_data/fairseq-py/train.py",
+        "--distributed-world-size",
+        str(args.num_nodes * args.num_gpus),
+        "--tpu",
+    ]
+    if not args.local:
+        cmd_args = [
+            "python",
+            "-m",
+            "torch_xla.distributed.xla_dist",
+            "--tpu",
+            args.tpu,
+            "--conda-env",
+            "torch-xla-nightly",
+            "--",
+        ] + cmd_args
+    if args.data:
+        cmd_args += [args.data]
+    cmd_args += ["--save-dir", save_dir]
+    for hp in config.values():
+        if hp.name == "--fp16":
+            hp.name = "--bf16"
+        cmd_args.extend(map(str, hp.get_cli_args()))
+    cmd_args_str = " ".join(map(shlex.quote, cmd_args))
+    if args.dry_run:
+        dry_run(f"train command: {cmd_args_str}")
+
+    # initialize train log
+    train_log = os.path.join(save_dir, "train.log")
+    if not dry_run(f"create train.log at: {train_log}"):
+        with open(train_log, "a") as train_log_h:
+            train_log_h.write("")
+        os.chmod(train_log, 0o777)
+
+    if args.dry_run:
+        print("| dry-run: start training")
+        print(f"| dry-run: - run command: {cmd_args_str}")
+    else:
+        subprocess.Popen(cmd_args).wait()
+
+    return train_log
+
+
+def has_started(save_dir):
+    train_log = os.path.join(save_dir, "train.log")
+    if not os.path.exists(train_log):
+        return False
+    return True
+
+
+def get_random_port():
+    old_state = random.getstate()
+    random.seed()
+    port = random.randint(10000, 20000)
+    random.setstate(old_state)
+    return port

--- a/fb_sweep/sweep_mega.py
+++ b/fb_sweep/sweep_mega.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+import sweep
+from sweep import hyperparam
+
+
+# Normal usage:
+# python -u train.py ${DATA} \
+#     --seed 0 --ddp-backend c10d --find-unused-parameters \
+#     -a mega_lra_listop --task lra-text --input-type text \
+#     --encoder-layers 6 --n-dim 16 --chunk-size $CHUNK \
+#     --activation-fn 'silu' --attention-activation-fn 'softmax' \
+#     --norm-type 'layernorm' --sen-rep-type 'mp' \
+#     --criterion lra_cross_entropy --best-checkpoint-metric accuracy --maximize-best-checkpoint-metric \
+#     --optimizer adam --lr 0.001 --adam-betas '(0.9, 0.98)' --adam-eps 1e-8 --clip-norm 1.0 \
+#     --dropout 0.1 --attention-dropout 0.0 --act-dropout 0.0 --weight-decay 0.01 \
+#     --batch-size 64 --sentence-avg --update-freq 1 --max-update 90000 --max-sentences-valid 256 \
+#     --lr-scheduler linear_decay --total-num-update 90000 --end-learning-rate 0.0 \
+#     --warmup-updates 3000 --warmup-init-lr '1e-07' --keep-last-epochs 1 --required-batch-size-multiple 1 \
+#     --save-dir ${SAVE} --log-format simple --log-interval 100 --num-workers 0
+
+def get_grid(args):
+    """
+    Replicates the `16-bit+cumul+2x lr` results from Table 1 of
+    "Scaling Neural Machine Translation" (https://arxiv.org/abs/1806.00187)
+    """
+    return [
+        hyperparam("--seed", 0),
+        hyperparam("--ddp-backend", "c10d"),
+        hyperparam("--find-unused-parameters"),
+        hyperparam("-a", "mega_lra_listop"),
+        hyperparam("--task", "lra-text"),
+        hyperparam("--input-type", "text"),
+        hyperparam("--encoder-layers", 6),
+        hyperparam("--n-dim", 16),
+        hyperparam("--chunk-size", -1),
+        hyperparam("--activation-fn", "silu"),
+        hyperparam("--attention-activation-fn", "softmax"),
+        hyperparam("--norm-type", "layernorm"),
+        hyperparam("--sen-rep-type", "mp"),
+        hyperparam("--criterion", "lra_cross_entropy"),
+        hyperparam("--best-checkpoint-metric", "accuracy"),
+        hyperparam("--maximize-best-checkpoint-metric"),
+        hyperparam("--optimizer", "adam"),
+        hyperparam("--lr", 0.001, save_dir_key=lambda val: f"lr{val}"),
+        hyperparam("--adam-betas", "(0.9, 0.98)"),
+        hyperparam("--adam-eps", 1e-8),
+        hyperparam("--clip-norm", 1.0),
+        hyperparam("--dropout", 0.1),
+        hyperparam("--attention-dropout", 0.0),
+        hyperparam("--act-dropout", 0.0),
+        hyperparam("--weight-decay", 0.01),
+        hyperparam("--batch-size", 8),
+        hyperparam("--sentence-avg"),
+        hyperparam("--update-freq", 1),
+        hyperparam("--max-update", 90000),
+        hyperparam("--max-sentences-valid", 256),
+        hyperparam("--lr-scheduler", "linear_decay"),
+        hyperparam("--total-num-update", 90000),
+        hyperparam("--end-learning-rate", 0.0),
+        hyperparam("--warmup-updates", 3000),
+        hyperparam("--warmup-init-lr", 1e-07),
+        hyperparam("--keep-last-epochs", 1),
+        hyperparam("--required-batch-size-multiple", 1),
+        #hyperparam("--save-dir", args.save_dir),
+        hyperparam("--log-format", "simple"),
+        hyperparam("--log-interval", 100),
+        hyperparam("--num-workers", 0),
+    ]
+
+
+def postprocess_hyperparams(args, config):
+    """Postprocess a given hyperparameter configuration."""
+    pass
+
+
+if __name__ == "__main__":
+    sweep.main(get_grid, postprocess_hyperparams)


### PR DESCRIPTION
This is an experiment to try to asses the impact of the individual modules in MEGA, as well as other elements of the training tricks.

The goal is to reduce the MegaAttention module to something that is as close as possible to a "vanilla" single attention head, and otherwise use exactly the same hyperparameters and training code.

At the moment, the target is only ListOps.

I imported some utilities to be able to run the jobs on slurm.
The command line is 
```
python ./fb_sweep/sweep_mega.py --prefix "mega_LRA_vanilla" -t -1 --partition devlab --num-gpus 8 --data /checkpoint/alcinos/data/lra/listops --constraint volta32gb
```
where all the parameters suggested for ListOps are set in the sweep_mega.py file.

With the default code, I got 63.25% acc, with the modified one I got 47.25%. This is significantly higher than the transformer's number from the paper (37.11), and in facts higher than most baselines including big-bird, etc.

My main question now is what differences remain between the code that I ran and a standard transformer baseline.